### PR TITLE
Cleans up unique key warning in Suggestions component

### DIFF
--- a/client/src/Components/Suggestions.js
+++ b/client/src/Components/Suggestions.js
@@ -54,7 +54,7 @@ class Suggestions extends Component {
             .join(`<b>${this.props.query.toLowerCase()}</b>`)
         };
         return (
-          <div className={classes.queryResult}>
+          <div className={classes.queryResult} key={article.url}>
             <ListItem
               className={classes.queryLabel}
               key={article.url}


### PR DESCRIPTION
No relevant JIRA ticket for this task, but adding this change from Renee's comment in a previous PR.

Fixes console warning: 
Warning: Each child in a list should have a unique "key" prop.

Check the render method of Suggestions. See https://fb.me/react-warning-keys for more information.
in div (at Suggestions.js:57)
in Suggestions (created by WithStyles(Suggestions))
in WithStyles(Suggestions) (at LandingPage.js:128)
in div (created by Grid)
in Grid (created by WithStyles(Grid))
in WithStyles(Grid) (at LandingPage.js:121)
in div (created by Grid)
in Grid (created by WithStyles(Grid))
in WithStyles(Grid) (at LandingPage.js:120)
in div (created by Paper)
in Paper (created by WithStyles(Paper))
in WithStyles(Paper) (at LandingPage.js:119)
in div (at LandingPage.js:118)
in LandingPage (created by WithStyles(LandingPage))
in WithStyles(LandingPage) (at App.js:8)
in div (at App.js:7)
in App (at src/index.js:6)