### PR TITLE
Make news screen responsive

### DIFF
--- a/client/src/Components/App.js
+++ b/client/src/Components/App.js
@@ -10,6 +10,7 @@ import Login from "./Login";
 
 const styles = {
   root: {
+    display: "flex",
     fontFamily: "Avenir",
     fontStyle: "normal",
     fontWeight: 400,
@@ -18,6 +19,9 @@ const styles = {
     `,
     unicodeRange:
       "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF",
+  },
+  App: {
+    display: "flex",
   },
 };
 
@@ -29,7 +33,7 @@ class App extends Component {
     const { classes } = this.props;
     console.log("AppStyles", this.props);
     return (
-      <div className="App">
+      <div className={classes.App}>
         <div className={classes.root}>
           <CssBaseline />
           <Router>

--- a/client/src/Components/LandingPage.js
+++ b/client/src/Components/LandingPage.js
@@ -16,8 +16,8 @@ const styles = () => ({
     display: "flex",
     flexDirection: "column",
     minHeight: "100vh",
-    maxWidth: 576,
     margin: "0 auto",
+    width: "100vw",
     padding: 0,
   },
   landingPageMain: {

--- a/client/src/Components/NewsCard.js
+++ b/client/src/Components/NewsCard.js
@@ -1,10 +1,8 @@
 import React, { Component } from "react";
 import classnames from "classnames";
 import PropTypes from "prop-types";
-
 import { withStyles } from "@material-ui/core/styles";
 import BookMark from "@material-ui/icons/BookmarkBorder";
-import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
 import CardActions from "@material-ui/core/CardActions";
 import CardContent from "@material-ui/core/CardContent";
@@ -13,16 +11,26 @@ import Collapse from "@material-ui/core/Collapse";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import IconButton from "@material-ui/core/IconButton";
 import Pause from "@material-ui/icons/NotInterested";
+import FavoriteBorderOutlinedIcon from "@material-ui/icons/FavoriteBorderOutlined";
+import ShareOutlinedIcon from "@material-ui/icons/ShareOutlined";
 
 import Typography from "@material-ui/core/Typography";
 
 import defaultImage from ".././images/default-image.png";
 
+import green from "@material-ui/core/colors/green";
+
 const calculateArticleAge = require("../Helpers/calculateArticleAge");
+//const calculateDate = require("../Helpers/calculateDate");
+
+const primary = green[50];
 
 const styles = () => ({
   newsCard: {
-    paddingBottom: 20,
+    borderRadius: 50,
+    paddingBottom: 30,
+    marginBottom: 30,
+    background: `${primary}`,
   },
   newsCardImage: {
     paddingTop: "56.25%",
@@ -31,25 +39,30 @@ const styles = () => ({
     display: "block",
     margin: 0,
     padding: 20,
+    //fontFamily: `${theme}`,
     fontSize: "1rem",
     fontWeight: "bold",
   },
-  newsCardArticleAge: {
+  newsCardArticle: {
     marginTop: 12,
+    //fontFamily: `${theme}`,
     fontSize: "0.875rem",
     textTransform: "uppercase",
   },
   newsCardArticleSourceName: {
     display: "inline-block",
     float: "left",
+    //fontFamily: `${theme}`,
     fontWeight: "bold",
   },
   newsCardArticleAge: {
+    //fontFamily: `${theme}`,
     display: "inline-block",
     float: "right",
   },
   newsCardContent: {
     fontSize: "1rem",
+    //fontFamily: `${theme}`,
   },
   expand: {
     transform: "rotate(0deg)",
@@ -80,24 +93,38 @@ class NewsCard extends Component {
   render() {
     const { classes, article } = this.props;
     const newsCardArticleAge = calculateArticleAge(article.publishedAt);
+    //const newsCardDate =  calculateDate(article.publishedAt);
+    //newsCardDate should go where article.publishedAt is undernearth the article source name
+
     return (
       <Card className={classes.newsCard}>
         <CardMedia
           className={classes.newsCardImage}
           image={article.urlToImage || defaultImage}
-          title={article.source.name}
         />
-        <CardContent>
-          <Typography className={classes.newsCardTitle}>
-            {article.title}
+        <div className={classes.newsCardArticle}>
+          <Typography className={classes.newsCardArticleSourceName}>
+            {article.source.name}
           </Typography>
           <Typography className={classes.newsCardArticleAge}>
             {newsCardArticleAge}
           </Typography>
+        </div>
+        <CardContent>
+          <Typography className={classes.newsCardTitle}>
+            {article.title}
+          </Typography>
         </CardContent>
+        <br />
         <CardActions
           className={!this.state.expanded ? classes.actions : classes.actionOne}
         >
+          <IconButton aria-label="share">
+            <ShareOutlinedIcon />
+          </IconButton>
+          <IconButton aria-label="add to favorites">
+            <FavoriteBorderOutlinedIcon />
+          </IconButton>
           <IconButton aria-label="Pause">
             <Pause />
           </IconButton>
@@ -119,10 +146,7 @@ class NewsCard extends Component {
           <CardContent>
             <Typography paragraph>By {article.author}</Typography>
             <Typography paragraph>
-              {article.content}
-              <Button fontWeight="bold" size="small" color="primary">
-                <a href={article.url}>Read More</a>
-              </Button>
+              {article.content} <a href={article.url}>Read More</a>
             </Typography>
           </CardContent>
         </Collapse>

--- a/client/src/Components/NewsCard.js
+++ b/client/src/Components/NewsCard.js
@@ -21,7 +21,6 @@ import defaultImage from ".././images/default-image.png";
 import green from "@material-ui/core/colors/green";
 
 const calculateArticleAge = require("../Helpers/calculateArticleAge");
-//const calculateDate = require("../Helpers/calculateDate");
 
 const primary = green[50];
 
@@ -39,30 +38,25 @@ const styles = () => ({
     display: "block",
     margin: 0,
     padding: 20,
-    //fontFamily: `${theme}`,
     fontSize: "1rem",
     fontWeight: "bold",
   },
   newsCardArticle: {
     marginTop: 12,
-    //fontFamily: `${theme}`,
     fontSize: "0.875rem",
     textTransform: "uppercase",
   },
   newsCardArticleSourceName: {
     display: "inline-block",
     float: "left",
-    //fontFamily: `${theme}`,
     fontWeight: "bold",
   },
   newsCardArticleAge: {
-    //fontFamily: `${theme}`,
     display: "inline-block",
     float: "right",
   },
   newsCardContent: {
     fontSize: "1rem",
-    //fontFamily: `${theme}`,
   },
   expand: {
     transform: "rotate(0deg)",
@@ -93,8 +87,6 @@ class NewsCard extends Component {
   render() {
     const { classes, article } = this.props;
     const newsCardArticleAge = calculateArticleAge(article.publishedAt);
-    //const newsCardDate =  calculateDate(article.publishedAt);
-    //newsCardDate should go where article.publishedAt is undernearth the article source name
 
     return (
       <Card className={classes.newsCard}>


### PR DESCRIPTION
Complete ticket
https://trello.com/c/TIrJYIDj/16-make-news-screen-responsive

Currently the screens are designed/built for mobile screens only, use CSS media queries and/or Flexbox to make the screen responsive to resize for both desktop and mobile screens.